### PR TITLE
Fix dataset deletion and add download support

### DIFF
--- a/app/api/endpoints/datasets.py
+++ b/app/api/endpoints/datasets.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, Body
+from fastapi import APIRouter, Body, HTTPException
+from fastapi.responses import FileResponse
 from app.controllers import dataset_controller
 from typing import Optional
+import os
 
 router = APIRouter()
 
@@ -21,6 +23,14 @@ async def list_dates_available_per_collection(site_id : str):
 @router.get("/datasets")
 async def list_datasets():
     return dataset_controller.list_datasets()
+
+@router.get("/dataset/download/{name}")
+async def download_dataset(name: str):
+    try:
+        file_path = dataset_controller.download_dataset(name)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+    return FileResponse(file_path, filename=os.path.basename(file_path))
 
 @router.delete("/dataset/{name}")
 async def delete_dataset(name: str):

--- a/app/controllers/dataset_controller.py
+++ b/app/controllers/dataset_controller.py
@@ -11,3 +11,7 @@ def list_datasets():
 
 def delete_dataset(name: str):
     return dataset_service.delete_dataset(name)
+
+
+def download_dataset(name: str):
+    return dataset_service.get_dataset_file(name)

--- a/app/services/dataset_service.py
+++ b/app/services/dataset_service.py
@@ -15,3 +15,7 @@ def delete_dataset(name: str):
     if not success:
         raise FileNotFoundError(f"Dataset {name} not found")
     return {"message": f"Dataset '{name}' deleted"}
+
+
+def get_dataset_file(name: str) -> str:
+    return file_utils.get_dataset_file(name)

--- a/app/utils/file_utils.py
+++ b/app/utils/file_utils.py
@@ -1,15 +1,18 @@
 import os, json, yaml, base64
-from app.config import settings
-from app.utils import mongo_utils
+import tempfile
 from datetime import datetime, timezone, timedelta
 from zoneinfo import ZoneInfo
 from collections import OrderedDict
-from fastapi import HTTPException
-import numpy as np
-import pandas as pd
 import shutil
 import logging
 import math
+
+import numpy as np
+import pandas as pd
+from fastapi import HTTPException
+
+from app.config import settings
+from app.utils import mongo_utils
 
 def save_config_dict(config: dict, file_name: str) -> str:
     full_path = os.path.join(settings.CONFIGS_DIR, file_name)
@@ -540,12 +543,56 @@ def list_dates_available_per_collection(site_id: str):
 
     return results
 
+def _get_path_size(path: str) -> int:
+    """Return total size in bytes for a file or directory."""
+    if os.path.isfile(path):
+        return os.path.getsize(path)
+    total = 0
+    for dirpath, _, filenames in os.walk(path):
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            try:
+                total += os.path.getsize(fp)
+            except OSError:
+                pass
+    return total
+
+
 def list_available_datasets():
-    return [d for d in os.listdir(settings.DATASETS_DIR) if os.path.isdir(os.path.join(settings.DATASETS_DIR, d))]
+    datasets = []
+    if not os.path.exists(settings.DATASETS_DIR):
+        return datasets
+
+    for name in os.listdir(settings.DATASETS_DIR):
+        path = os.path.join(settings.DATASETS_DIR, name)
+        if not os.path.exists(path):
+            continue
+        size = _get_path_size(path)
+        created_at = datetime.fromtimestamp(os.path.getctime(path)).isoformat()
+        datasets.append({"name": name, "size": size, "created_at": created_at})
+    return datasets
+
+
+def get_dataset_file(name: str) -> str:
+    """Return a path to the dataset file. If the dataset is a directory it will be zipped."""
+    path = os.path.join(settings.DATASETS_DIR, name)
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Dataset {name} not found")
+
+    if os.path.isdir(path):
+        tmp_dir = tempfile.gettempdir()
+        archive_base = os.path.join(tmp_dir, name)
+        archive_path = shutil.make_archive(archive_base, 'zip', path)
+        return archive_path
+    return path
+
 
 def delete_dataset_by_name(name: str) -> bool:
     path = os.path.join(settings.DATASETS_DIR, name)
-    if os.path.exists(path) and os.path.isdir(path):
-        shutil.rmtree(path)
+    if os.path.exists(path):
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+        else:
+            os.remove(path)
         return True
     return False

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,69 @@
+import os
+import importlib
+import pytest
+import sys
+from pathlib import Path
+
+@pytest.fixture
+def dataset_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("VM_SHARED_DATA", str(tmp_path))
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    import app.config as config
+    importlib.reload(config)
+    config.settings.DATASETS_DIR = os.path.join(config.settings.VM_SHARED_DATA, "datasets")
+    from app.utils import file_utils
+    importlib.reload(file_utils)
+    return file_utils, config.settings
+
+def test_list_datasets_returns_metadata(dataset_env):
+    file_utils, settings = dataset_env
+    datasets_dir = settings.DATASETS_DIR
+    os.makedirs(datasets_dir, exist_ok=True)
+
+    dir_path = os.path.join(datasets_dir, "dir_ds")
+    os.makedirs(dir_path)
+    with open(os.path.join(dir_path, "a.txt"), "w") as f:
+        f.write("hi")
+
+    file_path = os.path.join(datasets_dir, "file_ds.csv")
+    with open(file_path, "w") as f:
+        f.write("data")
+
+    datasets = file_utils.list_available_datasets()
+    names = {d["name"] for d in datasets}
+    assert "dir_ds" in names
+    assert "file_ds.csv" in names
+    dir_meta = next(d for d in datasets if d["name"] == "dir_ds")
+    assert dir_meta["size"] > 0
+    assert "created_at" in dir_meta
+
+def test_delete_dataset_by_name(dataset_env):
+    file_utils, settings = dataset_env
+    datasets_dir = settings.DATASETS_DIR
+    os.makedirs(datasets_dir, exist_ok=True)
+
+    dir_path = os.path.join(datasets_dir, "dir_ds")
+    os.makedirs(dir_path)
+    file_path = os.path.join(datasets_dir, "file_ds.csv")
+    with open(file_path, "w") as f:
+        f.write("data")
+
+    assert file_utils.delete_dataset_by_name("dir_ds")
+    assert not os.path.exists(dir_path)
+    assert file_utils.delete_dataset_by_name("file_ds.csv")
+    assert not os.path.exists(file_path)
+
+def test_get_dataset_file_zips_directory(dataset_env):
+    file_utils, settings = dataset_env
+    datasets_dir = settings.DATASETS_DIR
+    os.makedirs(datasets_dir, exist_ok=True)
+
+    dir_path = os.path.join(datasets_dir, "dir_ds")
+    os.makedirs(dir_path)
+    with open(os.path.join(dir_path, "a.txt"), "w") as f:
+        f.write("hi")
+
+    archive_path = file_utils.get_dataset_file("dir_ds")
+    assert archive_path.endswith(".zip")
+    assert os.path.exists(archive_path)
+    os.remove(archive_path)


### PR DESCRIPTION
## Summary
- allow dataset deletion for both folders and files
- expose dataset download endpoint and include metadata in dataset listings
- test dataset utilities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689212b7a32c83319a31acbdd62c535b