### PR TITLE
Fix dataset deletion, add download support, and document job states

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,8 @@ This will start:
 | GET    | /experiment-configs/{file}              | View a config file                                                         |
 | DELETE | /experiment-configs/{file}              | Delete a config file                                                       |
 | POST   | /dataset                                | Create a new dataset from a MongoDB site (buildings + EVs to CSVs)         |
-| GET    | /datasets                               | List all available datasets                                                |
+| GET    | /datasets                               | List all available datasets with metadata      |
+| GET    | /dataset/download/{name}                | Download a dataset (zips directories)          |
 | DELETE | /dataset/{name}                         | Delete a dataset and its contents                                          |
 | GET    | /dataset/dates-available/{site}         | Check available dates to generate a dataset                                |
 | GET    | /hosts                                  | List all available hosts                                                   |
@@ -199,6 +200,19 @@ Simulation outputs are persisted under `/opt/opeva_shared_data/jobs/{job_id}/`:
 - Results: `results/result.json`
 - Progress: `progress/progress.json`
 - Metadata: `job_info.json`
+
+## Job States
+Jobs transition through these states:
+- `pending` – request recorded before the container starts
+- `dispatched` – job handed off to a remote host and awaiting start
+- `running` – simulation executing inside the container (local jobs skip `dispatched`)
+- `completed` – container exited successfully
+- `failed` – container exited with an error code
+- `stopped` – job manually terminated via the API
+
+Retrieve the current state with `GET /status/{job_id}`. Progress updates remain
+on disk so clients can poll `GET /progress/{job_id}` whenever they need the
+latest values.
 
 ---
 
@@ -346,8 +360,14 @@ curl -X POST http://<IP>:8000/dataset \
 ```
 
 ### 📃 List Datasets
+List dataset names along with size and creation time.
 ```bash
 curl http://<IP>:8000/datasets
+```
+
+### 💾 Download Dataset
+```bash
+curl -L http://<IP>:8000/dataset/download/dataset1 -o dataset1.zip
 ```
 
 ### ❌ Delete Dataset

--- a/app/api/endpoints/datasets.py
+++ b/app/api/endpoints/datasets.py
@@ -1,6 +1,8 @@
-from fastapi import APIRouter, Body
+from fastapi import APIRouter, Body, HTTPException
+from fastapi.responses import FileResponse
 from app.controllers import dataset_controller
 from typing import Optional
+import os
 
 router = APIRouter()
 
@@ -22,6 +24,17 @@ async def list_dates_available_per_collection(site_id : str):
 async def list_datasets():
     return dataset_controller.list_datasets()
 
+@router.get("/dataset/download/{name}")
+async def download_dataset(name: str):
+    try:
+        file_path = dataset_controller.download_dataset(name)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+    return FileResponse(file_path, filename=os.path.basename(file_path))
+
 @router.delete("/dataset/{name}")
 async def delete_dataset(name: str):
-    return dataset_controller.delete_dataset(name)
+    try:
+        return dataset_controller.delete_dataset(name)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Dataset not found")

--- a/app/controllers/dataset_controller.py
+++ b/app/controllers/dataset_controller.py
@@ -11,3 +11,7 @@ def list_datasets():
 
 def delete_dataset(name: str):
     return dataset_service.delete_dataset(name)
+
+
+def download_dataset(name: str):
+    return dataset_service.get_dataset_file(name)

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from pydantic import BaseModel
 from typing import Optional, Dict
 
@@ -10,3 +11,13 @@ class JobLaunchRequest(BaseModel):
 class SimulationRequest(BaseModel):
     config_path: str
     job_name: Optional[str] = None
+
+
+class JobStatus(str, Enum):
+    PENDING = "pending"
+    DISPATCHED = "dispatched"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    STOPPED = "stopped"
+

--- a/app/services/dataset_service.py
+++ b/app/services/dataset_service.py
@@ -15,3 +15,7 @@ def delete_dataset(name: str):
     if not success:
         raise FileNotFoundError(f"Dataset {name} not found")
     return {"message": f"Dataset '{name}' deleted"}
+
+
+def get_dataset_file(name: str) -> str:
+    return file_utils.get_dataset_file(name)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+Example job artifacts for testing the API.
+Copy a folder from this directory into the server's jobs directory to test
+result, log and progress endpoints.

--- a/examples/sample_job/logs/sample_job.log
+++ b/examples/sample_job/logs/sample_job.log
@@ -1,0 +1,4 @@
+[INFO] Simulation started
+[INFO] Running step 1
+[INFO] Running step 2
+[INFO] Simulation completed

--- a/examples/sample_job/progress/progress.json
+++ b/examples/sample_job/progress/progress.json
@@ -1,0 +1,4 @@
+{
+  "percent": 100,
+  "stage": "complete"
+}

--- a/examples/sample_job/results/result.json
+++ b/examples/sample_job/results/result.json
@@ -1,0 +1,5 @@
+{
+  "status": "completed",
+  "summary": "Sample result output",
+  "metrics": {"accuracy": 0.95}
+}

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,69 @@
+import os
+import importlib
+import pytest
+import sys
+from pathlib import Path
+
+@pytest.fixture
+def dataset_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("VM_SHARED_DATA", str(tmp_path))
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    import app.config as config
+    importlib.reload(config)
+    config.settings.DATASETS_DIR = os.path.join(config.settings.VM_SHARED_DATA, "datasets")
+    from app.utils import file_utils
+    importlib.reload(file_utils)
+    return file_utils, config.settings
+
+def test_list_datasets_returns_metadata(dataset_env):
+    file_utils, settings = dataset_env
+    datasets_dir = settings.DATASETS_DIR
+    os.makedirs(datasets_dir, exist_ok=True)
+
+    dir_path = os.path.join(datasets_dir, "dir_ds")
+    os.makedirs(dir_path)
+    with open(os.path.join(dir_path, "a.txt"), "w") as f:
+        f.write("hi")
+
+    file_path = os.path.join(datasets_dir, "file_ds.csv")
+    with open(file_path, "w") as f:
+        f.write("data")
+
+    datasets = file_utils.list_available_datasets()
+    names = {d["name"] for d in datasets}
+    assert "dir_ds" in names
+    assert "file_ds.csv" in names
+    dir_meta = next(d for d in datasets if d["name"] == "dir_ds")
+    assert dir_meta["size"] > 0
+    assert "created_at" in dir_meta
+
+def test_delete_dataset_by_name(dataset_env):
+    file_utils, settings = dataset_env
+    datasets_dir = settings.DATASETS_DIR
+    os.makedirs(datasets_dir, exist_ok=True)
+
+    dir_path = os.path.join(datasets_dir, "dir_ds")
+    os.makedirs(dir_path)
+    file_path = os.path.join(datasets_dir, "file_ds.csv")
+    with open(file_path, "w") as f:
+        f.write("data")
+
+    assert file_utils.delete_dataset_by_name("dir_ds")
+    assert not os.path.exists(dir_path)
+    assert file_utils.delete_dataset_by_name("file_ds.csv")
+    assert not os.path.exists(file_path)
+
+def test_get_dataset_file_zips_directory(dataset_env):
+    file_utils, settings = dataset_env
+    datasets_dir = settings.DATASETS_DIR
+    os.makedirs(datasets_dir, exist_ok=True)
+
+    dir_path = os.path.join(datasets_dir, "dir_ds")
+    os.makedirs(dir_path)
+    with open(os.path.join(dir_path, "a.txt"), "w") as f:
+        f.write("hi")
+
+    archive_path = file_utils.get_dataset_file("dir_ds")
+    assert archive_path.endswith(".zip")
+    assert os.path.exists(archive_path)
+    os.remove(archive_path)

--- a/tests/test_job_states.py
+++ b/tests/test_job_states.py
@@ -1,0 +1,43 @@
+import sys
+from pathlib import Path
+import types
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+class _DummyRemote:
+    def __init__(self, func):
+        self.func = func
+
+    def remote(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
+
+
+ray_stub = types.SimpleNamespace(
+    init=lambda *args, **kwargs: None,
+    remote=lambda f: _DummyRemote(f),
+    get=lambda x: x,
+)
+sys.modules.setdefault("ray", ray_stub)
+
+from app.services import job_service
+from app.models.job import JobStatus
+
+
+def test_get_status_local_created(monkeypatch):
+    job_service.jobs['job1'] = {'container_id': 'abc', 'target_host': 'local'}
+    monkeypatch.setattr(job_service.docker_manager, 'get_container_status', lambda cid: ('created', None))
+    monkeypatch.setattr(job_service.job_utils, 'save_job', lambda *args, **kwargs: None)
+    status = job_service.get_status('job1')
+    assert status['status'] == JobStatus.RUNNING.value
+    job_service.jobs.pop('job1', None)
+
+
+def test_get_status_remote_created(monkeypatch):
+    job_service.jobs['job2'] = {'container_id': 'abc', 'target_host': 'remote', 'status': JobStatus.DISPATCHED.value}
+    monkeypatch.setattr(job_service.docker_manager, 'get_container_status', lambda cid: ('created', None))
+    monkeypatch.setattr(job_service.job_utils, 'save_job', lambda *args, **kwargs: None)
+    status = job_service.get_status('job2')
+    assert status['status'] == JobStatus.DISPATCHED.value
+    job_service.jobs.pop('job2', None)


### PR DESCRIPTION
## Summary
- allow dataset deletion for both folders and files
- expose dataset download endpoint and include metadata in dataset listings
- test dataset utilities
- track job states (pending, dispatched, running, completed, failed, stopped)
- stream job logs and remove progress files after each read
- provide sample job artifacts for testing
- keep progress files for polling and document job lifecycle
- handle dataset deletion errors and clarify dispatched state semantics
- test job status mapping for local and remote jobs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689212b7a32c83319a31acbdd62c535b